### PR TITLE
batched index for spot lights, temp.

### DIFF
--- a/DeferredTexturing/BindlessDeferred/MeshRenderer.h
+++ b/DeferredTexturing/BindlessDeferred/MeshRenderer.h
@@ -87,6 +87,8 @@ public:
     void RenderSunShadowMap(ID3D12GraphicsCommandList* cmdList, const Camera& camera);
     void RenderSpotLightShadowMap(ID3D12GraphicsCommandList* cmdList, const Camera& camera);
 
+    void RenderSpotLightShadowMapByBatch(ID3D12GraphicsCommandList* cmdList, const Camera& camera);
+
     const DepthBuffer& SunShadowMap() const { return sunShadowMap; }
     const DepthBuffer& SpotLightShadowMap() const { return spotLightShadowMap; }
     const Float4x4* SpotLightShadowMatrices() const { return spotLightShadowMatrices; }
@@ -99,6 +101,9 @@ protected:
     void RenderDepth(ID3D12GraphicsCommandList* cmdList, const Camera& camera, ID3D12PipelineState* pso, uint64 numVisible);
 
     void RenderDepthByBatch(ID3D12GraphicsCommandList* cmdList, const Camera& camera, ID3D12PipelineState* pso, uint64 numVisible);
+
+    void BatchIndexBufferForAllLights(const Camera& camera);
+    void BatchIndexForLight(uint64 idxLight, uint64 numVisible);
 
     const Model* model = nullptr;
 
@@ -126,9 +131,16 @@ protected:
     Array<uint32> meshDrawIndices;
     Array<float> meshZDepths;
 
+    //// Index Buffer batch for all spot lights
 	Array<uint16>   batchedIndices;
+    Array<uint32>   batchedOffset;
 	FormattedBuffer batchedIndexBuffer;
-	uint32 batchedIndexCount = 0;
+    uint64          numBatchedSpotLights;
+	uint32          batchedIndexCount = 0;
+    uint64          numPreVisibleTriangle = 0;
+    uint32          numIndexInModel = 0;
+    Array<uint32> meshDrawIndicesPre;
+
 
     SunShadowConstantsDepthMap sunShadowConstants;
 };

--- a/DeferredTexturing/SampleFramework12/v1.01/Utility.h
+++ b/DeferredTexturing/SampleFramework12/v1.01/Utility.h
@@ -148,6 +148,12 @@ inline uint32 GetIndex(const void* indices, uint32 idx, uint32 indexSize)
         return reinterpret_cast<const uint32*>(indices)[idx];
 }
 
+// Gets an index from an index buffer
+template<typename T>
+T GetValue(const void* indices, uint32 idx)
+{
+    return reinterpret_cast<const T*>(indices)[idx];
+}
 
 template<typename T, uint64 N>
 uint64 ArraySize(T(&)[N])


### PR DESCRIPTION
-  Try to implement Batch Drawing for spot light shadow map rendering. I found it takes a long time during a frame rendering.
  - first cull meshes against current spot light.
  -  then get a list of visible mesh.
  -  batch visible meshes together to draw by a single draw call.
- Not complete yet.